### PR TITLE
Add Core Commands

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -32,6 +32,7 @@ dependencies {
     implementation("org.jetbrains:annotations:24.0.0")
     implementation("dev.rollczi:litecommands-bukkit:3.9.5")
     implementation("dev.rollczi:litecommands-adventure:3.9.5")
+    implementation("dev.triumphteam:triumph-gui:3.1.11")
 }
 
 bukkit {
@@ -53,7 +54,8 @@ tasks.withType<ShadowJar> {
     archiveVersion.set("")
     archiveClassifier.set("")
 
-    relocate("dev.rollczi.litecommands", "dev.portero.atlas.litecommands")
+    relocate("dev.rollczi.litecommands", "dev.portero.atlas.commands")
+    relocate("dev.triumphteam.gui", "dev.portero.atlas.gui")
 }
 
 tasks.withType<RunServer> {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,7 +4,7 @@ import xyz.jpenilla.runpaper.task.RunServer
 plugins {
     id("java-library")
     id("com.gradleup.shadow") version "9.0.0-beta4"
-    id("net.minecrell.plugin-yml.bukkit") version "0.6.0"
+    id("de.eldoria.plugin-yml.bukkit") version "0.6.0"
     id("xyz.jpenilla.run-paper") version "2.3.1"
 }
 
@@ -29,10 +29,14 @@ repositories {
 
 dependencies {
     compileOnly("io.papermc.paper:paper-api:1.21.4-R0.1-SNAPSHOT")
+
     implementation("org.jetbrains:annotations:24.0.0")
-    implementation("dev.rollczi:litecommands-bukkit:3.9.5")
-    implementation("dev.rollczi:litecommands-adventure:3.9.5")
+    implementation("dev.rollczi:litecommands-bukkit:3.9.6")
+    implementation("dev.rollczi:litecommands-adventure:3.9.6")
     implementation("dev.triumphteam:triumph-gui:3.1.11")
+
+    compileOnly("org.projectlombok:lombok:1.18.36")
+    annotationProcessor("org.projectlombok:lombok:1.18.36")
 }
 
 bukkit {

--- a/src/main/java/dev/portero/atlas/AtlasPlugin.java
+++ b/src/main/java/dev/portero/atlas/AtlasPlugin.java
@@ -1,8 +1,10 @@
 package dev.portero.atlas;
 
 import dev.portero.atlas.cmd.AtlasCMD;
+import dev.portero.atlas.cmd.RestartCMD;
 import dev.portero.atlas.handler.CustomInvalidUsageHandler;
 import dev.portero.atlas.handler.MissingPermissionHandler;
+import dev.portero.atlas.manager.RestartManager;
 import dev.rollczi.litecommands.LiteCommands;
 import dev.rollczi.litecommands.adventure.LiteAdventureExtension;
 import dev.rollczi.litecommands.bukkit.LiteBukkitFactory;
@@ -18,10 +20,15 @@ public class AtlasPlugin extends JavaPlugin {
 
     @Override
     public void onEnable() {
+        RestartManager restartManager = new RestartManager();
+
         this.loadConfig();
 
         this.liteCommands = LiteBukkitFactory.builder("atlas", this)
-                .commands(new AtlasCMD(this))
+                .commands(
+                        new AtlasCMD(this),
+                        new RestartCMD(this, restartManager)
+                )
                 .extension(new LiteAdventureExtension<>(), config -> config
                         .miniMessage(true)
                         .legacyColor(true)

--- a/src/main/java/dev/portero/atlas/AtlasPlugin.java
+++ b/src/main/java/dev/portero/atlas/AtlasPlugin.java
@@ -2,10 +2,12 @@ package dev.portero.atlas;
 
 import dev.portero.atlas.cmd.AtlasCMD;
 import dev.portero.atlas.cmd.ChatManagerCMD;
+import dev.portero.atlas.cmd.MechanicCMD;
 import dev.portero.atlas.cmd.RestartCMD;
 import dev.portero.atlas.handler.CustomInvalidUsageHandler;
 import dev.portero.atlas.handler.MissingPermissionHandler;
 import dev.portero.atlas.listener.ChatManagerListener;
+import dev.portero.atlas.listener.mechanic.TntExplodeListener;
 import dev.portero.atlas.manager.ChatManager;
 import dev.portero.atlas.manager.RestartManager;
 import dev.rollczi.litecommands.LiteCommands;
@@ -32,7 +34,8 @@ public class AtlasPlugin extends JavaPlugin {
                 .commands(
                         new AtlasCMD(this),
                         new RestartCMD(this, restartManager),
-                        new ChatManagerCMD(chatManager)
+                        new ChatManagerCMD(chatManager),
+                        new MechanicCMD()
                 )
                 .extension(new LiteAdventureExtension<>(), config -> config
                         .miniMessage(true)
@@ -45,6 +48,7 @@ public class AtlasPlugin extends JavaPlugin {
                 .build();
 
         this.getServer().getPluginManager().registerEvents(new ChatManagerListener(chatManager), this);
+        this.getServer().getPluginManager().registerEvents(new TntExplodeListener(this), this);
     }
 
     @Override

--- a/src/main/java/dev/portero/atlas/AtlasPlugin.java
+++ b/src/main/java/dev/portero/atlas/AtlasPlugin.java
@@ -35,7 +35,7 @@ public class AtlasPlugin extends JavaPlugin {
                         new AtlasCMD(this),
                         new RestartCMD(restartManager),
                         new ChatManagerCMD(chatManager),
-                        new MechanicCMD()
+                        new MechanicCMD(this)
                 )
                 .extension(new LiteAdventureExtension<>(), config -> config
                         .miniMessage(true)

--- a/src/main/java/dev/portero/atlas/AtlasPlugin.java
+++ b/src/main/java/dev/portero/atlas/AtlasPlugin.java
@@ -25,7 +25,7 @@ public class AtlasPlugin extends JavaPlugin {
 
     @Override
     public void onEnable() {
-        RestartManager restartManager = new RestartManager();
+        RestartManager restartManager = new RestartManager(this);
         ChatManager chatManager = new ChatManager();
 
         this.loadConfig();
@@ -33,7 +33,7 @@ public class AtlasPlugin extends JavaPlugin {
         this.liteCommands = LiteBukkitFactory.builder("atlas", this)
                 .commands(
                         new AtlasCMD(this),
-                        new RestartCMD(this, restartManager),
+                        new RestartCMD(restartManager),
                         new ChatManagerCMD(chatManager),
                         new MechanicCMD()
                 )

--- a/src/main/java/dev/portero/atlas/AtlasPlugin.java
+++ b/src/main/java/dev/portero/atlas/AtlasPlugin.java
@@ -1,9 +1,12 @@
 package dev.portero.atlas;
 
 import dev.portero.atlas.cmd.AtlasCMD;
+import dev.portero.atlas.cmd.ChatManagerCMD;
 import dev.portero.atlas.cmd.RestartCMD;
 import dev.portero.atlas.handler.CustomInvalidUsageHandler;
 import dev.portero.atlas.handler.MissingPermissionHandler;
+import dev.portero.atlas.listener.ChatManagerListener;
+import dev.portero.atlas.manager.ChatManager;
 import dev.portero.atlas.manager.RestartManager;
 import dev.rollczi.litecommands.LiteCommands;
 import dev.rollczi.litecommands.adventure.LiteAdventureExtension;
@@ -21,13 +24,15 @@ public class AtlasPlugin extends JavaPlugin {
     @Override
     public void onEnable() {
         RestartManager restartManager = new RestartManager();
+        ChatManager chatManager = new ChatManager();
 
         this.loadConfig();
 
         this.liteCommands = LiteBukkitFactory.builder("atlas", this)
                 .commands(
                         new AtlasCMD(this),
-                        new RestartCMD(this, restartManager)
+                        new RestartCMD(this, restartManager),
+                        new ChatManagerCMD(chatManager)
                 )
                 .extension(new LiteAdventureExtension<>(), config -> config
                         .miniMessage(true)
@@ -38,6 +43,8 @@ public class AtlasPlugin extends JavaPlugin {
                 .missingPermission(new MissingPermissionHandler())
                 .invalidUsage(new CustomInvalidUsageHandler())
                 .build();
+
+        this.getServer().getPluginManager().registerEvents(new ChatManagerListener(chatManager), this);
     }
 
     @Override

--- a/src/main/java/dev/portero/atlas/AtlasPlugin.java
+++ b/src/main/java/dev/portero/atlas/AtlasPlugin.java
@@ -18,8 +18,10 @@ public class AtlasPlugin extends JavaPlugin {
 
     @Override
     public void onEnable() {
+        this.loadConfig();
+
         this.liteCommands = LiteBukkitFactory.builder("atlas", this)
-                .commands(new AtlasCMD())
+                .commands(new AtlasCMD(this))
                 .extension(new LiteAdventureExtension<>(), config -> config
                         .miniMessage(true)
                         .legacyColor(true)
@@ -36,5 +38,10 @@ public class AtlasPlugin extends JavaPlugin {
         if (this.liteCommands != null) {
             this.liteCommands.unregister();
         }
+    }
+
+    private void loadConfig() {
+        this.getConfig().options().copyDefaults(true);
+        this.saveDefaultConfig();
     }
 }

--- a/src/main/java/dev/portero/atlas/cmd/AtlasCMD.java
+++ b/src/main/java/dev/portero/atlas/cmd/AtlasCMD.java
@@ -1,16 +1,39 @@
 package dev.portero.atlas.cmd;
 
-import dev.portero.atlas.lang.Messages;
 import dev.rollczi.litecommands.annotations.command.Command;
 import dev.rollczi.litecommands.annotations.context.Context;
 import dev.rollczi.litecommands.annotations.execute.Execute;
+import io.papermc.paper.plugin.configuration.PluginMeta;
 import org.bukkit.command.CommandSender;
+import org.bukkit.plugin.Plugin;
+
+import static dev.portero.atlas.util.MessageUtil.centerDecorated;
+import static dev.portero.atlas.util.MessageUtil.format;
+import static net.kyori.adventure.text.format.NamedTextColor.AQUA;
 
 @Command(name = "atlas")
 public class AtlasCMD {
 
+    private final Plugin plugin;
+
+    public AtlasCMD(Plugin plugin) {
+        this.plugin = plugin;
+    }
+
+
     @Execute
+    @SuppressWarnings("UnstableApiUsage")
     public void execute(@Context CommandSender sender) {
-        Messages.WELCOME.send(sender);
+        PluginMeta pluginMeta = plugin.getPluginMeta();
+
+        String name = pluginMeta.getName();
+        String version = pluginMeta.getVersion();
+        String author = String.join(", ", pluginMeta.getAuthors());
+
+        sender.sendMessage(centerDecorated(AQUA, "&r&7[ &bAtlas33 &7→ &cINFO &7]"));
+        sender.sendMessage(format("&bName: &7" + name));
+        sender.sendMessage(format("&bVersion: &7" + version));
+        sender.sendMessage(format("&bAuthor: &7" + author));
+        sender.sendMessage(centerDecorated(AQUA, ""));
     }
 }

--- a/src/main/java/dev/portero/atlas/cmd/AtlasCMD.java
+++ b/src/main/java/dev/portero/atlas/cmd/AtlasCMD.java
@@ -3,15 +3,17 @@ package dev.portero.atlas.cmd;
 import dev.rollczi.litecommands.annotations.command.Command;
 import dev.rollczi.litecommands.annotations.context.Context;
 import dev.rollczi.litecommands.annotations.execute.Execute;
+import dev.rollczi.litecommands.annotations.permission.Permission;
 import io.papermc.paper.plugin.configuration.PluginMeta;
 import org.bukkit.command.CommandSender;
 import org.bukkit.plugin.Plugin;
 
 import static dev.portero.atlas.util.MessageUtil.centerDecorated;
 import static dev.portero.atlas.util.MessageUtil.format;
-import static net.kyori.adventure.text.format.NamedTextColor.AQUA;
+import static net.kyori.adventure.text.format.NamedTextColor.GRAY;
 
 @Command(name = "atlas")
+@Permission("atlas.cmd.base")
 public class AtlasCMD {
 
     private final Plugin plugin;
@@ -30,10 +32,10 @@ public class AtlasCMD {
         String version = pluginMeta.getVersion();
         String author = String.join(", ", pluginMeta.getAuthors());
 
-        sender.sendMessage(centerDecorated(AQUA, "&r&7[ &bAtlas33 &7→ &cINFO &7]"));
-        sender.sendMessage(format("&bName: &7" + name));
-        sender.sendMessage(format("&bVersion: &7" + version));
-        sender.sendMessage(format("&bAuthor: &7" + author));
-        sender.sendMessage(centerDecorated(AQUA, ""));
+        sender.sendMessage(centerDecorated(GRAY, "&r[ &aATLAS &7→ &cINFO &7]"));
+        sender.sendMessage(format("  • &aName: &7" + name));
+        sender.sendMessage(format("  • &aVersion: &7" + version));
+        sender.sendMessage(format("  • &aAuthor: &7" + author));
+        sender.sendMessage(centerDecorated(GRAY, ""));
     }
 }

--- a/src/main/java/dev/portero/atlas/cmd/ChatManagerCMD.java
+++ b/src/main/java/dev/portero/atlas/cmd/ChatManagerCMD.java
@@ -21,22 +21,22 @@ public class ChatManagerCMD {
     @Execute(name = "slow")
     public void execute(@Context CommandSender sender, @Arg int seconds) {
         if (seconds < 1) {
-            if (chatManager.getSlowModeSeconds() == 0) {
+            if (chatManager.getSlowModeDuration() == 0) {
                 Messages.ChatManager.SLOW_MODE_ALREADY_DISABLED.send(sender);
                 return;
             }
 
-            chatManager.setSlowModeSeconds(0);
+            chatManager.setSlowModeDuration(0);
             Messages.ChatManager.SLOW_MODE_DISABLED.broadcast();
             return;
         }
 
-        if(chatManager.getSlowModeSeconds() == seconds) {
+        if (chatManager.getSlowModeDuration() == seconds) {
             Messages.ChatManager.SLOW_MODE_ALREADY.send(sender, seconds);
             return;
         }
 
-        chatManager.setSlowModeSeconds(seconds);
+        chatManager.setSlowModeDuration(seconds);
         Messages.ChatManager.SLOW_MODE_ENABLED.broadcast(seconds);
     }
 

--- a/src/main/java/dev/portero/atlas/cmd/ChatManagerCMD.java
+++ b/src/main/java/dev/portero/atlas/cmd/ChatManagerCMD.java
@@ -1,0 +1,75 @@
+package dev.portero.atlas.cmd;
+
+import dev.portero.atlas.lang.Messages;
+import dev.portero.atlas.manager.ChatManager;
+import dev.rollczi.litecommands.annotations.argument.Arg;
+import dev.rollczi.litecommands.annotations.command.Command;
+import dev.rollczi.litecommands.annotations.context.Context;
+import dev.rollczi.litecommands.annotations.execute.Execute;
+import dev.rollczi.litecommands.annotations.shortcut.Shortcut;
+import lombok.RequiredArgsConstructor;
+import net.kyori.adventure.text.Component;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+
+@RequiredArgsConstructor
+@Command(name = "chatmanager", aliases = {"cm"})
+public class ChatManagerCMD {
+
+    private final ChatManager chatManager;
+
+    @Execute(name = "slow")
+    public void execute(@Context CommandSender sender, @Arg int seconds) {
+        if (seconds < 1) {
+            if (chatManager.getSlowModeSeconds() == 0) {
+                Messages.ChatManager.SLOW_MODE_ALREADY_DISABLED.send(sender);
+                return;
+            }
+
+            chatManager.setSlowModeSeconds(0);
+            Messages.ChatManager.SLOW_MODE_DISABLED.broadcast();
+            return;
+        }
+
+        if(chatManager.getSlowModeSeconds() == seconds) {
+            Messages.ChatManager.SLOW_MODE_ALREADY.send(sender, seconds);
+            return;
+        }
+
+        chatManager.setSlowModeSeconds(seconds);
+        Messages.ChatManager.SLOW_MODE_ENABLED.broadcast(seconds);
+    }
+
+    @Execute(name = "enable")
+    public void enable(@Context CommandSender sender) {
+        if (!chatManager.isDisabled()) {
+            Messages.ChatManager.CHAT_ALREADY_ENABLED.send(sender);
+            return;
+        }
+
+        chatManager.setDisabled(false);
+        Messages.ChatManager.CHAT_ENABLED.broadcast();
+    }
+
+    @Execute(name = "disable")
+    public void disable(@Context CommandSender sender) {
+        if (chatManager.isDisabled()) {
+            Messages.ChatManager.CHAT_ALREADY_DISABLED.send(sender);
+            return;
+        }
+
+        chatManager.setDisabled(true);
+        Messages.ChatManager.CHAT_DISABLED.broadcast();
+    }
+
+    @Execute(name = "clear")
+    @Shortcut("cc")
+    public void clear(@Context CommandSender sender) {
+        for (Player player : sender.getServer().getOnlinePlayers()) {
+            for (int i = 0; i < 30; i++) {
+                player.sendMessage(Component.empty());
+            }
+        }
+        Messages.ChatManager.CHAT_CLEARED.broadcast(sender instanceof Player ? sender.getName() : "CONSOLE");
+    }
+}

--- a/src/main/java/dev/portero/atlas/cmd/ChatManagerCMD.java
+++ b/src/main/java/dev/portero/atlas/cmd/ChatManagerCMD.java
@@ -42,23 +42,23 @@ public class ChatManagerCMD {
 
     @Execute(name = "enable")
     public void enable(@Context CommandSender sender) {
-        if (!chatManager.isDisabled()) {
+        if (!chatManager.isChatDisabled()) {
             Messages.ChatManager.CHAT_ALREADY_ENABLED.send(sender);
             return;
         }
 
-        chatManager.setDisabled(false);
+        chatManager.setChatDisabled(false);
         Messages.ChatManager.CHAT_ENABLED.broadcast();
     }
 
     @Execute(name = "disable")
     public void disable(@Context CommandSender sender) {
-        if (chatManager.isDisabled()) {
+        if (chatManager.isChatDisabled()) {
             Messages.ChatManager.CHAT_ALREADY_DISABLED.send(sender);
             return;
         }
 
-        chatManager.setDisabled(true);
+        chatManager.setChatDisabled(true);
         Messages.ChatManager.CHAT_DISABLED.broadcast();
     }
 

--- a/src/main/java/dev/portero/atlas/cmd/MechanicCMD.java
+++ b/src/main/java/dev/portero/atlas/cmd/MechanicCMD.java
@@ -1,0 +1,21 @@
+package dev.portero.atlas.cmd;
+
+import dev.portero.atlas.lang.Messages;
+import dev.portero.atlas.mechanic.MechanicType;
+import dev.rollczi.litecommands.annotations.argument.Arg;
+import dev.rollczi.litecommands.annotations.command.Command;
+import dev.rollczi.litecommands.annotations.execute.Execute;
+
+@Command(name = "mechanicmanager", aliases = {"mm"})
+public class MechanicCMD {
+
+    @Execute(name = "enable")
+    public void enable(@Arg MechanicType mechanic) {
+        Messages.MechanicCommand.ENABLED.broadcast(mechanic);
+    }
+
+    @Execute(name = "disable")
+    public void disable(@Arg MechanicType mechanic) {
+        Messages.MechanicCommand.DISABLED.broadcast(mechanic);
+    }
+}

--- a/src/main/java/dev/portero/atlas/cmd/MechanicCMD.java
+++ b/src/main/java/dev/portero/atlas/cmd/MechanicCMD.java
@@ -5,17 +5,28 @@ import dev.portero.atlas.mechanic.MechanicType;
 import dev.rollczi.litecommands.annotations.argument.Arg;
 import dev.rollczi.litecommands.annotations.command.Command;
 import dev.rollczi.litecommands.annotations.execute.Execute;
+import org.bukkit.plugin.Plugin;
 
 @Command(name = "mechanicmanager", aliases = {"mm"})
 public class MechanicCMD {
 
+    private final Plugin plugin;
+
+    public MechanicCMD(Plugin plugin) {
+        this.plugin = plugin;
+    }
+
     @Execute(name = "enable")
     public void enable(@Arg MechanicType mechanic) {
+        plugin.getConfig().set(mechanic.getPath(), true);
+        plugin.saveConfig();
         Messages.MechanicCommand.ENABLED.broadcast(mechanic);
     }
 
     @Execute(name = "disable")
     public void disable(@Arg MechanicType mechanic) {
+        plugin.getConfig().set(mechanic.getPath(), false);
+        plugin.saveConfig();
         Messages.MechanicCommand.DISABLED.broadcast(mechanic);
     }
 }

--- a/src/main/java/dev/portero/atlas/cmd/RestartCMD.java
+++ b/src/main/java/dev/portero/atlas/cmd/RestartCMD.java
@@ -11,11 +11,7 @@ import org.bukkit.Bukkit;
 import org.bukkit.Sound;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
-import org.bukkit.plugin.Plugin;
-import org.bukkit.scheduler.BukkitRunnable;
 
-import java.util.ArrayList;
-import java.util.Collection;
 import java.util.Optional;
 
 @RequiredArgsConstructor
@@ -23,69 +19,29 @@ import java.util.Optional;
 public class RestartCMD {
 
     private static final int DEFAULT_RESTART_TIME = 10;
-
-    private final Plugin plugin;
     private final RestartManager restartManager;
 
     @Execute
-    public void execute(@Arg Optional<Integer> seconds) {
-        this.startRestartCountdown(seconds.orElse(DEFAULT_RESTART_TIME));
+    public void execute(@Context CommandSender sender, @Arg Optional<Integer> seconds) {
+        if (restartManager.isRestartTaskRunning()) {
+            Messages.Restart.ALREADY_RUNNING.send(sender);
+            return;
+        }
+
+        restartManager.initiateRestartCountdown(seconds.orElse(DEFAULT_RESTART_TIME));
     }
 
     @Execute(name = "cancel")
     public void cancel(@Context CommandSender sender) {
-        this.handleCancel(sender);
-    }
-
-    private void startRestartCountdown(int seconds) {
-        this.restartManager.setTask(new BukkitRunnable() {
-            private int count = seconds;
-
-            @Override
-            public void run() {
-                if (count > 0) {
-                    handleCountdownTick(count);
-                } else if (count == 0) {
-                    handleRestart();
-                } else {
-                    plugin.getServer().shutdown();
-                    this.cancel();
-                }
-
-                count--;
-            }
-        }.runTaskTimer(plugin, 0, 20));
-    }
-
-    private void handleCountdownTick(int seconds) {
-        if ((seconds % 60 == 0) || (seconds % 10 == 0 && seconds < 60) || (seconds <= 5)) {
-            Messages.Restart.RESTART.broadcast(seconds);
-            this.playSoundForPlayers(this.getOnlinePlayers(), Sound.BLOCK_NOTE_BLOCK_PLING, 1f);
-        }
-    }
-
-    private void handleRestart() {
-        Bukkit.getServer().savePlayers();
-        Messages.Restart.RESTARTING.broadcast();
-        this.playSoundForPlayers(this.getOnlinePlayers(), Sound.BLOCK_NOTE_BLOCK_PLING, 1.5f);
-    }
-
-    private void handleCancel(CommandSender sender) {
-        if (this.restartManager.getTask().isCancelled()) {
+        if (!restartManager.isRestartTaskRunning()) {
             Messages.Restart.TASK_NOT_FOUND.send(sender);
             return;
         }
 
-        this.restartManager.getTask().cancel();
+        restartManager.cancelRestart();
         Messages.Restart.CANCELLED.broadcast(sender instanceof Player ? sender.getName() : "CONSOLE");
-        playSoundForPlayers(getOnlinePlayers(), Sound.BLOCK_ANVIL_USE, 1);
-    }
-
-    private void playSoundForPlayers(Collection<Player> players, Sound sound, float pitch) {
-        players.forEach(player -> player.playSound(player.getLocation(), sound, 1, pitch));
-    }
-
-    private Collection<Player> getOnlinePlayers() {
-        return new ArrayList<>(Bukkit.getServer().getOnlinePlayers());
+        Bukkit.getOnlinePlayers().forEach(player ->
+                player.playSound(player.getLocation(), Sound.BLOCK_ANVIL_USE, 1, 1)
+        );
     }
 }

--- a/src/main/java/dev/portero/atlas/cmd/RestartCMD.java
+++ b/src/main/java/dev/portero/atlas/cmd/RestartCMD.java
@@ -1,0 +1,91 @@
+package dev.portero.atlas.cmd;
+
+import dev.portero.atlas.lang.Messages;
+import dev.portero.atlas.manager.RestartManager;
+import dev.rollczi.litecommands.annotations.argument.Arg;
+import dev.rollczi.litecommands.annotations.command.Command;
+import dev.rollczi.litecommands.annotations.context.Context;
+import dev.rollczi.litecommands.annotations.execute.Execute;
+import lombok.RequiredArgsConstructor;
+import org.bukkit.Bukkit;
+import org.bukkit.Sound;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+import org.bukkit.plugin.Plugin;
+import org.bukkit.scheduler.BukkitRunnable;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Optional;
+
+@RequiredArgsConstructor
+@Command(name = "restart")
+public class RestartCMD {
+
+    private static final int DEFAULT_RESTART_TIME = 10;
+
+    private final Plugin plugin;
+    private final RestartManager restartManager;
+
+    @Execute
+    public void execute(@Arg Optional<Integer> seconds) {
+        this.startRestartCountdown(seconds.orElse(DEFAULT_RESTART_TIME));
+    }
+
+    @Execute(name = "cancel")
+    public void cancel(@Context CommandSender sender) {
+        this.handleCancel(sender);
+    }
+
+    private void startRestartCountdown(int seconds) {
+        this.restartManager.setTask(new BukkitRunnable() {
+            private int count = seconds;
+
+            @Override
+            public void run() {
+                if (count > 0) {
+                    handleCountdownTick(count);
+                } else if (count == 0) {
+                    handleRestart();
+                } else {
+                    plugin.getServer().shutdown();
+                    this.cancel();
+                }
+
+                count--;
+            }
+        }.runTaskTimer(plugin, 0, 20));
+    }
+
+    private void handleCountdownTick(int seconds) {
+        if ((seconds % 60 == 0) || (seconds % 10 == 0 && seconds < 60) || (seconds <= 5)) {
+            Messages.Restart.RESTART.broadcast(seconds);
+            this.playSoundForPlayers(this.getOnlinePlayers(), Sound.BLOCK_NOTE_BLOCK_PLING, 1f);
+        }
+    }
+
+    private void handleRestart() {
+        Bukkit.getServer().savePlayers();
+        Messages.Restart.RESTARTING.broadcast();
+        this.playSoundForPlayers(this.getOnlinePlayers(), Sound.BLOCK_NOTE_BLOCK_PLING, 1.5f);
+    }
+
+    private void handleCancel(CommandSender sender) {
+        if (this.restartManager.getTask().isCancelled()) {
+            Messages.Restart.TASK_NOT_FOUND.send(sender);
+            return;
+        }
+
+        this.restartManager.getTask().cancel();
+        Messages.Restart.CANCELLED.broadcast(sender instanceof Player ? sender.getName() : "CONSOLE");
+        playSoundForPlayers(getOnlinePlayers(), Sound.BLOCK_ANVIL_USE, 1);
+    }
+
+    private void playSoundForPlayers(Collection<Player> players, Sound sound, float pitch) {
+        players.forEach(player -> player.playSound(player.getLocation(), sound, 1, pitch));
+    }
+
+    private Collection<Player> getOnlinePlayers() {
+        return new ArrayList<>(Bukkit.getServer().getOnlinePlayers());
+    }
+}

--- a/src/main/java/dev/portero/atlas/handler/CustomInvalidUsageHandler.java
+++ b/src/main/java/dev/portero/atlas/handler/CustomInvalidUsageHandler.java
@@ -12,6 +12,6 @@ public class CustomInvalidUsageHandler implements InvalidUsageHandler<CommandSen
     @Override
     public void handle(Invocation<CommandSender> invocation, InvalidUsage<CommandSender> result, ResultHandlerChain<CommandSender> chain) {
         CommandSender sender = invocation.sender();
-        Messages.ERROR_INVALID_USAGE.send(sender);
+        Messages.Error.INVALID_USAGE.send(sender);
     }
 }

--- a/src/main/java/dev/portero/atlas/handler/CustomInvalidUsageHandler.java
+++ b/src/main/java/dev/portero/atlas/handler/CustomInvalidUsageHandler.java
@@ -11,6 +11,7 @@ public class CustomInvalidUsageHandler implements InvalidUsageHandler<CommandSen
 
     @Override
     public void handle(Invocation<CommandSender> invocation, InvalidUsage<CommandSender> result, ResultHandlerChain<CommandSender> chain) {
-        Messages.ERROR_INVALID_USAGE.send(invocation.sender());
+        CommandSender sender = invocation.sender();
+        Messages.ERROR_INVALID_USAGE.send(sender);
     }
 }

--- a/src/main/java/dev/portero/atlas/handler/CustomInvalidUsageHandler.java
+++ b/src/main/java/dev/portero/atlas/handler/CustomInvalidUsageHandler.java
@@ -5,6 +5,7 @@ import dev.rollczi.litecommands.handler.result.ResultHandlerChain;
 import dev.rollczi.litecommands.invalidusage.InvalidUsage;
 import dev.rollczi.litecommands.invalidusage.InvalidUsageHandler;
 import dev.rollczi.litecommands.invocation.Invocation;
+import dev.rollczi.litecommands.schematic.Schematic;
 import org.bukkit.command.CommandSender;
 
 public class CustomInvalidUsageHandler implements InvalidUsageHandler<CommandSender> {
@@ -12,6 +13,14 @@ public class CustomInvalidUsageHandler implements InvalidUsageHandler<CommandSen
     @Override
     public void handle(Invocation<CommandSender> invocation, InvalidUsage<CommandSender> result, ResultHandlerChain<CommandSender> chain) {
         CommandSender sender = invocation.sender();
-        Messages.Error.INVALID_USAGE.send(sender);
+        Schematic schematic = result.getSchematic();
+
+        if(schematic.isOnlyFirst()) {
+            Messages.Error.InvalidUsage.ONLY_FIRST.send(sender, schematic.first());
+            return;
+        }
+
+        Messages.Error.InvalidUsage.TITLE.send(sender, schematic.first());
+        schematic.all().forEach(command -> Messages.Error.InvalidUsage.ARGS.send(sender, command));
     }
 }

--- a/src/main/java/dev/portero/atlas/handler/MissingPermissionHandler.java
+++ b/src/main/java/dev/portero/atlas/handler/MissingPermissionHandler.java
@@ -11,6 +11,6 @@ public class MissingPermissionHandler implements MissingPermissionsHandler<Comma
 
     @Override
     public void handle(Invocation<CommandSender> invocation, MissingPermissions missingPermissions, ResultHandlerChain<CommandSender> chain) {
-        Messages.ERROR_NO_PERMISSION.send(invocation.sender());
+        Messages.Error.NO_PERMISSION.send(invocation.sender());
     }
 }

--- a/src/main/java/dev/portero/atlas/lang/Messages.java
+++ b/src/main/java/dev/portero/atlas/lang/Messages.java
@@ -1,21 +1,50 @@
 package dev.portero.atlas.lang;
 
 import net.kyori.adventure.text.Component;
+import org.bukkit.Bukkit;
 import org.bukkit.command.CommandSender;
 
 import static net.kyori.adventure.text.Component.text;
-import static net.kyori.adventure.text.format.NamedTextColor.RED;
+import static net.kyori.adventure.text.format.NamedTextColor.*;
 
 public interface Messages {
 
-    Arg0 ERROR_NO_PERMISSION = () -> text("You don't have permission to do that!", RED);
-    Arg0 ERROR_INVALID_USAGE = () -> text("The command doesn't support the provided arguments!", RED);
+    interface Error {
+        Arg0 NO_PERMISSION = () -> text("You don't have permission to do that!", RED);
+        Arg0 INVALID_USAGE = () -> text("The command doesn't support the provided arguments!", RED);
+    }
+
+    interface Restart {
+        Arg1<Integer> RESTART = (seconds) -> text("[SERVER]", RED)
+                .appendSpace()
+                .append(text("The server will restart in", GRAY))
+                .appendSpace()
+                .append(text(seconds, YELLOW))
+                .appendSpace()
+                .append(text("seconds!", GRAY));
+        Arg0 RESTARTING = () -> text("[SERVER]", RED)
+                .appendSpace()
+                .append(text("The server is restarting!", GRAY));
+        Arg1<String> CANCELLED = (sender) -> text("[SERVER]", AQUA)
+                .appendSpace()
+                .append(text("The server restart has been cancelled by", GRAY))
+                .appendSpace()
+                .append(text(sender, YELLOW))
+                .append(text("!", GRAY));
+        Arg0 TASK_NOT_FOUND = () -> text("You cannot cancel a restart that is not scheduled!", RED);
+    }
 
     interface Arg0 {
         Component build();
 
         default void send(CommandSender sender) {
             sender.sendMessage(build());
+        }
+
+        default void broadcast() {
+            for (CommandSender sender : Bukkit.getServer().getOnlinePlayers()) {
+                sender.sendMessage(build());
+            }
         }
     }
 
@@ -24,6 +53,12 @@ public interface Messages {
 
         default void send(CommandSender sender, A0 a0) {
             sender.sendMessage(build(a0));
+        }
+
+        default void broadcast(A0 a0) {
+            for (CommandSender sender : Bukkit.getServer().getOnlinePlayers()) {
+                sender.sendMessage(build(a0));
+            }
         }
     }
 

--- a/src/main/java/dev/portero/atlas/lang/Messages.java
+++ b/src/main/java/dev/portero/atlas/lang/Messages.java
@@ -12,7 +12,22 @@ public interface Messages {
 
     interface Error {
         Arg0 NO_PERMISSION = () -> "&cYou don't have permission to do that!";
-        Arg0 INVALID_USAGE = () -> "&cThe command doesn't support the provided arguments!";
+
+        interface InvalidUsage {
+            Arg1<String> ONLY_FIRST = (name) -> "&cThe command &e" + name + "&c doesn't support the provided arguments!";
+            Arg1<String> TITLE = (cmd) -> "&cAvailable commands(" + cmd.split(" ")[0] + "):";
+            Arg1<String> ARGS = (cmd) -> {
+                String[] args = cmd.split(" ");
+                StringBuilder builder = new StringBuilder();
+                String[] colors = new String[]{"&7", "&c"};
+
+                builder.append("&8・");
+                for (int i = 0; i < args.length; i++) {
+                    builder.append(colors[i % colors.length]).append(args[i]).append(" ");
+                }
+                return builder.toString();
+            };
+        }
     }
 
     interface ChatManager {

--- a/src/main/java/dev/portero/atlas/lang/Messages.java
+++ b/src/main/java/dev/portero/atlas/lang/Messages.java
@@ -15,10 +15,31 @@ public interface Messages {
         Arg0 INVALID_USAGE = () -> "&cThe command doesn't support the provided arguments!";
     }
 
+    interface ChatManager {
+        Arg1<Integer> SLOW_MODE_ENABLED = (seconds) -> "&9[CHAT] &7Slow mode &aenabled&7! By &e" + seconds + "&7 seconds!";
+        Arg1<Integer> SLOW_MODE_ALREADY = (seconds) -> "&cSlow mode is already enabled by &e" + seconds + "&c seconds!";
+
+        Arg0 SLOW_MODE_DISABLED = () -> "&9[CHAT] &7Slow mode is now &cdisabled&7!";
+        Arg0 SLOW_MODE_ALREADY_DISABLED = () -> "&cSlow mode is already disabled!";
+
+        Arg0 CHAT_ENABLED = () -> "&9[CHAT] &7The chat is now &aenabled&7!";
+        Arg0 CHAT_ALREADY_ENABLED = () -> "&cThe chat is already enabled!";
+
+        Arg0 CHAT_DISABLED = () -> "&9[CHAT] &7The chat is now &cdisabled&7!";
+        Arg0 CHAT_ALREADY_DISABLED = () -> "&cThe chat is already disabled!";
+
+        Arg1<String> CHAT_CLEARED = (sender) -> "&9[CHAT] &7The chat has been &bcleared &7by &e" + sender + "&7!";
+
+        Arg0 DISABLED = () -> "&cYou cannot speak while the chat is disabled!";
+
+        Arg1<Integer> SLOWED = (seconds) -> "&cWait &e" + seconds + "&c seconds before sending another message!";
+
+    }
+
     interface Restart {
-        Arg1<Integer> RESTART = (seconds) -> "&c[SERVER] &7The server will restart in &e" + seconds + "&7 seconds!";
-        Arg0 RESTARTING = () -> "&c[SERVER] &7The server is restarting!";
-        Arg1<String> CANCELLED = (sender) -> "&b[SERVER] &7The server restart has been cancelled by &e" + sender + "&7!";
+        Arg1<Integer> RESTART = (seconds) -> "&c[SERVER] &7The server will &drestart &7in &e" + seconds + "&7 seconds!";
+        Arg0 RESTARTING = () -> "&c[SERVER] &7The server is &drestarting&7!";
+        Arg1<String> CANCELLED = (sender) -> "&c[SERVER] &7The server &drestart &7has been &ccancelled &7by &e" + sender + "&7!";
         Arg0 TASK_NOT_FOUND = () -> "&cYou cannot cancel a restart that is not scheduled!";
     }
 
@@ -38,7 +59,7 @@ public interface Messages {
         String message(A0 a0);
 
         default void send(CommandSender sender, A0 a0) {
-            sender.sendMessage(message(a0));
+            sender.sendMessage(serialize(message(a0)));
         }
 
         default void broadcast(A0 a0) {

--- a/src/main/java/dev/portero/atlas/lang/Messages.java
+++ b/src/main/java/dev/portero/atlas/lang/Messages.java
@@ -8,6 +8,8 @@ import org.bukkit.command.CommandSender;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.function.Supplier;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 public interface Messages {
 
@@ -19,14 +21,11 @@ public interface Messages {
             Arg1<String> TITLE = (cmd) -> "&cAvailable commands(" + cmd.split(" ")[0] + "):";
             Arg1<String> ARGS = (cmd) -> {
                 String[] args = cmd.split(" ");
-                StringBuilder builder = new StringBuilder();
-                String[] colors = new String[]{"&7", "&c"};
+                String[] colors = new String[]{"&7", "&c", "&e"};
 
-                builder.append("&8・");
-                for (int i = 0; i < args.length; i++) {
-                    builder.append(colors[i % colors.length]).append(args[i]).append(" ");
-                }
-                return builder.toString();
+                return "&8・" + IntStream.range(0, args.length)
+                        .mapToObj(i -> colors[i % colors.length] + args[i])
+                        .collect(Collectors.joining(" "));
             };
         }
     }

--- a/src/main/java/dev/portero/atlas/lang/Messages.java
+++ b/src/main/java/dev/portero/atlas/lang/Messages.java
@@ -4,14 +4,12 @@ import net.kyori.adventure.text.Component;
 import org.bukkit.command.CommandSender;
 
 import static net.kyori.adventure.text.Component.text;
-import static net.kyori.adventure.text.format.NamedTextColor.*;
+import static net.kyori.adventure.text.format.NamedTextColor.RED;
 
 public interface Messages {
 
     Arg0 ERROR_NO_PERMISSION = () -> text("You don't have permission to do that!", RED);
     Arg0 ERROR_INVALID_USAGE = () -> text("The command doesn't support the provided arguments!", RED);
-
-    Arg0 WELCOME = () -> text("Welcome to Atlas!", GOLD);
 
     interface Arg0 {
         Component build();
@@ -20,4 +18,13 @@ public interface Messages {
             sender.sendMessage(build());
         }
     }
+
+    interface Arg1<A0> {
+        Component build(A0 a0);
+
+        default void send(CommandSender sender, A0 a0) {
+            sender.sendMessage(build(a0));
+        }
+    }
+
 }

--- a/src/main/java/dev/portero/atlas/lang/Messages.java
+++ b/src/main/java/dev/portero/atlas/lang/Messages.java
@@ -1,65 +1,57 @@
 package dev.portero.atlas.lang;
 
-import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.TextComponent;
+import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
 import org.bukkit.Bukkit;
 import org.bukkit.command.CommandSender;
+import org.jetbrains.annotations.NotNull;
 
-import static net.kyori.adventure.text.Component.text;
-import static net.kyori.adventure.text.format.NamedTextColor.*;
+import java.util.function.Supplier;
 
 public interface Messages {
 
     interface Error {
-        Arg0 NO_PERMISSION = () -> text("You don't have permission to do that!", RED);
-        Arg0 INVALID_USAGE = () -> text("The command doesn't support the provided arguments!", RED);
+        Arg0 NO_PERMISSION = () -> "&cYou don't have permission to do that!";
+        Arg0 INVALID_USAGE = () -> "&cThe command doesn't support the provided arguments!";
     }
 
     interface Restart {
-        Arg1<Integer> RESTART = (seconds) -> text("[SERVER]", RED)
-                .appendSpace()
-                .append(text("The server will restart in", GRAY))
-                .appendSpace()
-                .append(text(seconds, YELLOW))
-                .appendSpace()
-                .append(text("seconds!", GRAY));
-        Arg0 RESTARTING = () -> text("[SERVER]", RED)
-                .appendSpace()
-                .append(text("The server is restarting!", GRAY));
-        Arg1<String> CANCELLED = (sender) -> text("[SERVER]", AQUA)
-                .appendSpace()
-                .append(text("The server restart has been cancelled by", GRAY))
-                .appendSpace()
-                .append(text(sender, YELLOW))
-                .append(text("!", GRAY));
-        Arg0 TASK_NOT_FOUND = () -> text("You cannot cancel a restart that is not scheduled!", RED);
+        Arg1<Integer> RESTART = (seconds) -> "&c[SERVER] &7The server will restart in &e" + seconds + "&7 seconds!";
+        Arg0 RESTARTING = () -> "&c[SERVER] &7The server is restarting!";
+        Arg1<String> CANCELLED = (sender) -> "&b[SERVER] &7The server restart has been cancelled by &e" + sender + "&7!";
+        Arg0 TASK_NOT_FOUND = () -> "&cYou cannot cancel a restart that is not scheduled!";
     }
 
     interface Arg0 {
-        Component build();
+        String message();
 
         default void send(CommandSender sender) {
-            sender.sendMessage(build());
+            sender.sendMessage(serialize(message()));
         }
 
         default void broadcast() {
-            for (CommandSender sender : Bukkit.getServer().getOnlinePlayers()) {
-                sender.sendMessage(build());
-            }
+            broadcastAll(() -> serialize(message()));
         }
     }
 
     interface Arg1<A0> {
-        Component build(A0 a0);
+        String message(A0 a0);
 
         default void send(CommandSender sender, A0 a0) {
-            sender.sendMessage(build(a0));
+            sender.sendMessage(message(a0));
         }
 
         default void broadcast(A0 a0) {
-            for (CommandSender sender : Bukkit.getServer().getOnlinePlayers()) {
-                sender.sendMessage(build(a0));
-            }
+            broadcastAll(() -> serialize(message(a0)));
         }
     }
 
+    static @NotNull TextComponent serialize(@NotNull String message) {
+        return LegacyComponentSerializer.legacyAmpersand().deserialize(message);
+    }
+
+    static void broadcastAll(Supplier<TextComponent> supplier) {
+        Bukkit.getServer().getOnlinePlayers().forEach(player -> player.sendMessage(supplier.get()));
+        Bukkit.getConsoleSender().sendMessage(supplier.get());
+    }
 }

--- a/src/main/java/dev/portero/atlas/lang/Messages.java
+++ b/src/main/java/dev/portero/atlas/lang/Messages.java
@@ -54,7 +54,6 @@ public interface Messages {
         Arg0 DISABLED = () -> "&cYou cannot speak while the chat is disabled!";
 
         Arg1<Integer> SLOWED = (seconds) -> "&cWait &e" + seconds + "&c seconds before sending another message!";
-
     }
 
     interface Restart {
@@ -62,6 +61,7 @@ public interface Messages {
         Arg0 RESTARTING = () -> "&c[SERVER] &7The server is &drestarting&7!";
         Arg1<String> CANCELLED = (sender) -> "&c[SERVER] &7The server &drestart &7has been &ccancelled &7by &e" + sender + "&7!";
         Arg0 TASK_NOT_FOUND = () -> "&cYou cannot cancel a restart that is not scheduled!";
+        Arg0 ALREADY_RUNNING = () -> "&cRestart already in progress! Try /restart cancel!";
     }
 
     interface Arg0 {

--- a/src/main/java/dev/portero/atlas/lang/Messages.java
+++ b/src/main/java/dev/portero/atlas/lang/Messages.java
@@ -1,5 +1,6 @@
 package dev.portero.atlas.lang;
 
+import dev.portero.atlas.mechanic.MechanicType;
 import net.kyori.adventure.text.TextComponent;
 import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
 import org.bukkit.Bukkit;
@@ -14,7 +15,7 @@ public interface Messages {
         Arg0 NO_PERMISSION = () -> "&cYou don't have permission to do that!";
 
         interface InvalidUsage {
-            Arg1<String> ONLY_FIRST = (name) -> "&cThe command &e" + name + "&c doesn't support the provided arguments!";
+            Arg1<String> ONLY_FIRST = (cmd) -> "&cThis command doesn't support the provided arguments!";
             Arg1<String> TITLE = (cmd) -> "&cAvailable commands(" + cmd.split(" ")[0] + "):";
             Arg1<String> ARGS = (cmd) -> {
                 String[] args = cmd.split(" ");
@@ -28,6 +29,11 @@ public interface Messages {
                 return builder.toString();
             };
         }
+    }
+
+    interface MechanicCommand {
+        Arg1<MechanicType> ENABLED = (mechanic) -> "&9[MECHANIC] &7The mechanic &e" + mechanic + "&7 is now &aenabled&7!";
+        Arg1<MechanicType> DISABLED = (mechanic) -> "&9[MECHANIC] &7The mechanic &e" + mechanic + "&7 is now &cdisabled&7!";
     }
 
     interface ChatManager {
@@ -79,6 +85,30 @@ public interface Messages {
 
         default void broadcast(A0 a0) {
             broadcastAll(() -> serialize(message(a0)));
+        }
+    }
+
+    interface Arg2<A0, A1> {
+        String message(A0 a0, A1 a1);
+
+        default void send(CommandSender sender, A0 a0, A1 a1) {
+            sender.sendMessage(serialize(message(a0, a1)));
+        }
+
+        default void broadcast(A0 a0, A1 a1) {
+            broadcastAll(() -> serialize(message(a0, a1)));
+        }
+    }
+
+    interface Arg3<A0, A1, A2> {
+        String message(A0 a0, A1 a1, A2 a2);
+
+        default void send(CommandSender sender, A0 a0, A1 a1, A2 a2) {
+            sender.sendMessage(serialize(message(a0, a1, a2)));
+        }
+
+        default void broadcast(A0 a0, A1 a1, A2 a2) {
+            broadcastAll(() -> serialize(message(a0, a1, a2)));
         }
     }
 

--- a/src/main/java/dev/portero/atlas/listener/ChatManagerListener.java
+++ b/src/main/java/dev/portero/atlas/listener/ChatManagerListener.java
@@ -1,0 +1,45 @@
+package dev.portero.atlas.listener;
+
+import dev.portero.atlas.lang.Messages;
+import dev.portero.atlas.manager.ChatManager;
+import io.papermc.paper.event.player.AsyncChatEvent;
+import lombok.RequiredArgsConstructor;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+
+import java.time.Instant;
+import java.util.Map;
+
+@RequiredArgsConstructor
+public class ChatManagerListener implements Listener {
+
+    private final ChatManager chatManager;
+
+    @EventHandler
+    public void onPlayerChat(AsyncChatEvent event) {
+        Player player = event.getPlayer();
+
+        if (chatManager.isDisabled()) {
+            event.setCancelled(true);
+            Messages.ChatManager.DISABLED.send(player);
+            return;
+        }
+
+        if (chatManager.getSlowModeSeconds() > 0) {
+            Map<String, Instant> messageCooldowns = chatManager.getMessageCooldowns();
+            if (messageCooldowns.containsKey(player.getName())) {
+                Instant lastMessage = messageCooldowns.get(player.getName());
+                long timeSinceLastMessage = System.currentTimeMillis() - lastMessage.toEpochMilli();
+                if (timeSinceLastMessage < chatManager.getSlowModeSeconds() * 1000L) {
+                    event.setCancelled(true);
+                    Messages.ChatManager.SLOWED.send(player, (int) (chatManager.getSlowModeSeconds() - timeSinceLastMessage / 1000L));
+                    return;
+                } else {
+                    messageCooldowns.remove(player.getName());
+                }
+            }
+            messageCooldowns.put(player.getName(), Instant.now());
+        }
+    }
+}

--- a/src/main/java/dev/portero/atlas/listener/ChatManagerListener.java
+++ b/src/main/java/dev/portero/atlas/listener/ChatManagerListener.java
@@ -20,14 +20,14 @@ public class ChatManagerListener implements Listener {
     public void onPlayerChat(AsyncChatEvent event) {
         Player player = event.getPlayer();
 
-        if (chatManager.isDisabled()) {
+        if (chatManager.isChatDisabled()) {
             event.setCancelled(true);
             Messages.ChatManager.DISABLED.send(player);
             return;
         }
 
         if (chatManager.getSlowModeSeconds() > 0) {
-            Map<String, Instant> messageCooldowns = chatManager.getMessageCooldowns();
+            Map<String, Instant> messageCooldowns = chatManager.getPlayerMessageTimestamps();
             if (messageCooldowns.containsKey(player.getName())) {
                 Instant lastMessage = messageCooldowns.get(player.getName());
                 long timeSinceLastMessage = System.currentTimeMillis() - lastMessage.toEpochMilli();

--- a/src/main/java/dev/portero/atlas/listener/ChatManagerListener.java
+++ b/src/main/java/dev/portero/atlas/listener/ChatManagerListener.java
@@ -8,9 +8,6 @@ import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 
-import java.time.Instant;
-import java.util.Map;
-
 @RequiredArgsConstructor
 public class ChatManagerListener implements Listener {
 
@@ -26,20 +23,18 @@ public class ChatManagerListener implements Listener {
             return;
         }
 
-        if (chatManager.getSlowModeSeconds() > 0) {
-            Map<String, Instant> messageCooldowns = chatManager.getPlayerMessageTimestamps();
-            if (messageCooldowns.containsKey(player.getName())) {
-                Instant lastMessage = messageCooldowns.get(player.getName());
-                long timeSinceLastMessage = System.currentTimeMillis() - lastMessage.toEpochMilli();
-                if (timeSinceLastMessage < chatManager.getSlowModeSeconds() * 1000L) {
-                    event.setCancelled(true);
-                    Messages.ChatManager.SLOWED.send(player, (int) (chatManager.getSlowModeSeconds() - timeSinceLastMessage / 1000L));
+        if (chatManager.getSlowModeDuration() > 0) {
+            if (chatManager.isUserOnCooldown(player.getUniqueId())) {
+                int remainingCooldown = chatManager.getRemainingCooldown(player.getUniqueId());
+                if (remainingCooldown <= 0) {
+                    chatManager.refreshUserCooldown(player.getUniqueId());
                     return;
-                } else {
-                    messageCooldowns.remove(player.getName());
                 }
+                Messages.ChatManager.SLOWED.send(player, remainingCooldown);
+                event.setCancelled(true);
+                return;
             }
-            messageCooldowns.put(player.getName(), Instant.now());
+            chatManager.addUserToCooldown(player.getUniqueId());
         }
     }
 }

--- a/src/main/java/dev/portero/atlas/listener/mechanic/TntExplodeListener.java
+++ b/src/main/java/dev/portero/atlas/listener/mechanic/TntExplodeListener.java
@@ -1,0 +1,91 @@
+package dev.portero.atlas.listener.mechanic;
+
+import lombok.RequiredArgsConstructor;
+import org.bukkit.*;
+import org.bukkit.block.Block;
+import org.bukkit.entity.EntityType;
+import org.bukkit.entity.FallingBlock;
+import org.bukkit.entity.Firework;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.entity.EntityExplodeEvent;
+import org.bukkit.inventory.meta.FireworkMeta;
+import org.bukkit.plugin.Plugin;
+import org.bukkit.util.Vector;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+
+@RequiredArgsConstructor
+public class TntExplodeListener implements Listener {
+
+    private final Plugin plugin;
+
+    @SuppressWarnings("deprecation")
+    @EventHandler
+    public void onTntExplode(EntityExplodeEvent event) {
+        if (event.getEntity().getType() != EntityType.TNT) {
+            return;
+        }
+
+        if (plugin.getConfig().getBoolean("mechanics.tnt_explode.enabled")) {
+            Firework firework = this.spawnFirework(event.getLocation(), FireworkEffect.builder()
+                    .with(FireworkEffect.Type.BALL_LARGE)
+                    .withColor(Color.RED)
+                    .withFade(Color.RED)
+                    .trail(true)
+                    .flicker(true)
+                    .build());
+
+            firework.detonate();
+        }
+
+        if (plugin.getConfig().getBoolean("mechanics.tnt_explode.enabled")) {
+
+            List<Block> blocks = new ArrayList<>(event.blockList());
+            List<FallingBlock> fallingBlocks = new ArrayList<>();
+
+            for (Block block : blocks) {
+                Location location = block.getLocation();
+
+                FallingBlock fallingBlock = location.getWorld().spawnFallingBlock(location, block.getBlockData());
+
+                fallingBlock.setBlockData(block.getBlockData());
+
+                fallingBlock.setVelocity(this.getRandomVelocity());
+                fallingBlock.setDropItem(false);
+                fallingBlock.setInvulnerable(true);
+
+                fallingBlocks.add(fallingBlock);
+            }
+
+            Bukkit.getScheduler().runTaskLater(plugin, () -> {
+                for (FallingBlock fallingBlock : fallingBlocks) {
+                    fallingBlock.getLocation().getBlock().setType(Material.AIR);
+                    fallingBlock.remove();
+                }
+            }, 5 * 20);
+        }
+
+    }
+
+    private Vector getRandomVelocity() {
+        Random random = new Random();
+        double x = random.nextDouble() * 2 - 1;
+        double y = random.nextDouble();
+        double z = random.nextDouble() * 2 - 1;
+        return new Vector(x, y, z).normalize().multiply(0.8);
+    }
+
+    private Firework spawnFirework(Location location, FireworkEffect effect) {
+        Firework firework = (Firework) location.getWorld().spawnEntity(location, EntityType.FIREWORK_ROCKET);
+        FireworkMeta meta = firework.getFireworkMeta();
+
+        meta.addEffect(effect);
+        meta.setPower(0);
+
+        firework.setFireworkMeta(meta);
+        return firework;
+    }
+}

--- a/src/main/java/dev/portero/atlas/listener/mechanic/TntExplodeListener.java
+++ b/src/main/java/dev/portero/atlas/listener/mechanic/TntExplodeListener.java
@@ -1,7 +1,10 @@
 package dev.portero.atlas.listener.mechanic;
 
 import lombok.RequiredArgsConstructor;
-import org.bukkit.*;
+import org.bukkit.Color;
+import org.bukkit.FireworkEffect;
+import org.bukkit.Location;
+import org.bukkit.Material;
 import org.bukkit.block.Block;
 import org.bukkit.entity.EntityType;
 import org.bukkit.entity.FallingBlock;
@@ -11,6 +14,7 @@ import org.bukkit.event.Listener;
 import org.bukkit.event.entity.EntityExplodeEvent;
 import org.bukkit.inventory.meta.FireworkMeta;
 import org.bukkit.plugin.Plugin;
+import org.bukkit.scheduler.BukkitRunnable;
 import org.bukkit.util.Vector;
 
 import java.util.ArrayList;
@@ -25,11 +29,9 @@ public class TntExplodeListener implements Listener {
     @SuppressWarnings("deprecation")
     @EventHandler
     public void onTntExplode(EntityExplodeEvent event) {
-        if (event.getEntity().getType() != EntityType.TNT) {
-            return;
-        }
-
         if (plugin.getConfig().getBoolean("mechanics.tnt_explode.enabled")) {
+            event.setYield(0);
+
             Firework firework = this.spawnFirework(event.getLocation(), FireworkEffect.builder()
                     .with(FireworkEffect.Type.BALL_LARGE)
                     .withColor(Color.RED)
@@ -47,25 +49,36 @@ public class TntExplodeListener implements Listener {
             List<FallingBlock> fallingBlocks = new ArrayList<>();
 
             for (Block block : blocks) {
-                Location location = block.getLocation();
+                Random random = new Random();
+                int chance = random.nextInt(0, 10);
 
-                FallingBlock fallingBlock = location.getWorld().spawnFallingBlock(location, block.getBlockData());
+                if (chance <= 2) {
+                    Location location = block.getLocation();
 
-                fallingBlock.setBlockData(block.getBlockData());
+                    FallingBlock fallingBlock = location.getWorld().spawnFallingBlock(location, block.getBlockData());
 
-                fallingBlock.setVelocity(this.getRandomVelocity());
-                fallingBlock.setDropItem(false);
-                fallingBlock.setInvulnerable(true);
+                    fallingBlock.setBlockData(block.getBlockData());
 
-                fallingBlocks.add(fallingBlock);
+                    fallingBlock.setVelocity(this.getRandomVelocity());
+                    fallingBlock.setDropItem(false);
+                    fallingBlock.setInvulnerable(true);
+
+                    fallingBlocks.add(fallingBlock);
+                }
             }
 
-            Bukkit.getScheduler().runTaskLater(plugin, () -> {
-                for (FallingBlock fallingBlock : fallingBlocks) {
-                    fallingBlock.getLocation().getBlock().setType(Material.AIR);
-                    fallingBlock.remove();
+            new BukkitRunnable() {
+                @Override
+                public void run() {
+                    if (fallingBlocks.isEmpty()) {
+                        this.cancel();
+                        return;
+                    }
+
+                    fallingBlocks.getLast().getLocation().getBlock().setType(Material.AIR);
+                    fallingBlocks.removeLast();
                 }
-            }, 5 * 20);
+            }.runTaskTimer(plugin, 20 * 2, 1);
         }
 
     }

--- a/src/main/java/dev/portero/atlas/listener/mechanic/TntExplodeListener.java
+++ b/src/main/java/dev/portero/atlas/listener/mechanic/TntExplodeListener.java
@@ -1,5 +1,6 @@
 package dev.portero.atlas.listener.mechanic;
 
+import dev.portero.atlas.mechanic.MechanicType;
 import lombok.RequiredArgsConstructor;
 import org.bukkit.Color;
 import org.bukkit.FireworkEffect;
@@ -29,9 +30,7 @@ public class TntExplodeListener implements Listener {
     @SuppressWarnings("deprecation")
     @EventHandler
     public void onTntExplode(EntityExplodeEvent event) {
-        if (plugin.getConfig().getBoolean("mechanics.tnt_explode.enabled")) {
-            event.setYield(0);
-
+        if (plugin.getConfig().getBoolean(MechanicType.EXPLOSION_FIREWORK.getPath())) {
             Firework firework = this.spawnFirework(event.getLocation(), FireworkEffect.builder()
                     .with(FireworkEffect.Type.BALL_LARGE)
                     .withColor(Color.RED)
@@ -43,8 +42,7 @@ public class TntExplodeListener implements Listener {
             firework.detonate();
         }
 
-        if (plugin.getConfig().getBoolean("mechanics.tnt_explode.enabled")) {
-
+        if (plugin.getConfig().getBoolean(MechanicType.EXPLOSION.getPath())) {
             List<Block> blocks = new ArrayList<>(event.blockList());
             List<FallingBlock> fallingBlocks = new ArrayList<>();
 

--- a/src/main/java/dev/portero/atlas/manager/ChatManager.java
+++ b/src/main/java/dev/portero/atlas/manager/ChatManager.java
@@ -9,8 +9,6 @@ import java.util.Map;
 @Data
 public class ChatManager {
     private int slowModeSeconds;
-
-    private boolean disabled;
-
-    private Map<String, Instant> messageCooldowns = new HashMap<>();
+    private boolean isChatDisabled;
+    private Map<String, Instant> playerMessageTimestamps = new HashMap<>();
 }

--- a/src/main/java/dev/portero/atlas/manager/ChatManager.java
+++ b/src/main/java/dev/portero/atlas/manager/ChatManager.java
@@ -1,0 +1,16 @@
+package dev.portero.atlas.manager;
+
+import lombok.Data;
+
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.Map;
+
+@Data
+public class ChatManager {
+    private int slowModeSeconds;
+
+    private boolean disabled;
+
+    private Map<String, Instant> messageCooldowns = new HashMap<>();
+}

--- a/src/main/java/dev/portero/atlas/manager/ChatManager.java
+++ b/src/main/java/dev/portero/atlas/manager/ChatManager.java
@@ -1,14 +1,44 @@
 package dev.portero.atlas.manager;
 
-import lombok.Data;
+import lombok.Getter;
+import lombok.Setter;
 
 import java.time.Instant;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.UUID;
 
-@Data
 public class ChatManager {
-    private int slowModeSeconds;
-    private boolean isChatDisabled;
-    private Map<String, Instant> playerMessageTimestamps = new HashMap<>();
+
+    @Setter
+    @Getter
+    private int slowModeDuration;
+
+    @Setter
+    @Getter
+    private boolean chatDisabled;
+
+    private final Map<UUID, Instant> userCooldowns;
+
+    public ChatManager() {
+        this.slowModeDuration = 0;
+        this.chatDisabled = false;
+        this.userCooldowns = new HashMap<>();
+    }
+
+    public void addUserToCooldown(UUID userId) {
+        this.userCooldowns.put(userId, Instant.now());
+    }
+
+    public void refreshUserCooldown(UUID userId) {
+        this.userCooldowns.put(userId, Instant.now());
+    }
+
+    public boolean isUserOnCooldown(UUID userId) {
+        return this.userCooldowns.containsKey(userId);
+    }
+
+    public int getRemainingCooldown(UUID userId) {
+        return (int) (this.slowModeDuration - (System.currentTimeMillis() - this.userCooldowns.get(userId).toEpochMilli()) / 1000L);
+    }
 }

--- a/src/main/java/dev/portero/atlas/manager/RestartManager.java
+++ b/src/main/java/dev/portero/atlas/manager/RestartManager.java
@@ -1,11 +1,76 @@
 package dev.portero.atlas.manager;
 
-import lombok.Getter;
-import lombok.Setter;
+import dev.portero.atlas.lang.Messages;
+import org.bukkit.Bukkit;
+import org.bukkit.Sound;
+import org.bukkit.plugin.Plugin;
+import org.bukkit.scheduler.BukkitRunnable;
 import org.bukkit.scheduler.BukkitTask;
 
-@Getter
-@Setter
 public class RestartManager {
-    private BukkitTask task;
+
+    private final Plugin plugin;
+    private BukkitTask restartTask;
+
+    public RestartManager(Plugin plugin) {
+        this.plugin = plugin;
+    }
+
+    public void initiateRestartCountdown(int durationInSeconds) {
+        this.restartTask = new BukkitRunnable() {
+            private int count = durationInSeconds;
+
+            @Override
+            public void run() {
+                if (count > 0) {
+                    handleCountdownTick(count);
+                } else if (count == 0) {
+                    executeServerRestart();
+                    this.cancel();
+                }
+
+                count--;
+            }
+        }.runTaskTimer(plugin, 0, 20);
+    }
+
+    public void cancelRestart() {
+        if (this.restartTask != null) {
+            this.restartTask.cancel();
+        }
+    }
+
+    public boolean isRestartTaskRunning() {
+        return this.restartTask != null && !this.restartTask.isCancelled();
+    }
+
+    private void executeServerRestart() {
+        Bukkit.getServer().savePlayers();
+        Messages.Restart.RESTARTING.broadcast();
+        this.playSoundForAllPlayers(1.5f);
+        new BukkitRunnable() {
+            @Override
+            public void run() {
+                plugin.getServer().shutdown();
+                this.cancel();
+            }
+        }.runTaskLater(plugin, 10);
+    }
+
+    private void handleCountdownTick(int remainingSeconds) {
+        if (shouldNotify(remainingSeconds)) {
+            Messages.Restart.RESTART.broadcast(remainingSeconds);
+            this.playSoundForAllPlayers(1f);
+        }
+    }
+
+    private boolean shouldNotify(int seconds) {
+        return seconds % 60 == 0 || (seconds % 10 == 0 && seconds < 60) || seconds <= 5;
+    }
+
+    private void playSoundForAllPlayers(float pitch) {
+        Bukkit.getServer().getOnlinePlayers().forEach(player ->
+                player.playSound(player.getLocation(), Sound.BLOCK_NOTE_BLOCK_PLING, 1, pitch)
+        );
+    }
 }

--- a/src/main/java/dev/portero/atlas/manager/RestartManager.java
+++ b/src/main/java/dev/portero/atlas/manager/RestartManager.java
@@ -1,0 +1,11 @@
+package dev.portero.atlas.manager;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.bukkit.scheduler.BukkitTask;
+
+@Getter
+@Setter
+public class RestartManager {
+    private BukkitTask task;
+}

--- a/src/main/java/dev/portero/atlas/mechanic/MechanicType.java
+++ b/src/main/java/dev/portero/atlas/mechanic/MechanicType.java
@@ -1,5 +1,16 @@
 package dev.portero.atlas.mechanic;
 
+import lombok.Getter;
+
+@Getter
 public enum MechanicType {
-    TNT_PLACE, TNT_EXPLODE, TNT_THROW
+    EXPLOSION_FIREWORK("explosion_firework"),
+    EXPLOSION("explosion"),
+    CORPSE("corpse");
+
+    private final String path;
+
+    MechanicType(String path) {
+        this.path = "mechanics." + path + ".enabled";
+    }
 }

--- a/src/main/java/dev/portero/atlas/mechanic/MechanicType.java
+++ b/src/main/java/dev/portero/atlas/mechanic/MechanicType.java
@@ -1,0 +1,5 @@
+package dev.portero.atlas.mechanic;
+
+public enum MechanicType {
+    TNT_PLACE, TNT_EXPLODE, TNT_THROW
+}

--- a/src/main/java/dev/portero/atlas/text/FontInfo.java
+++ b/src/main/java/dev/portero/atlas/text/FontInfo.java
@@ -1,4 +1,4 @@
-package dev.portero.atlas.util;
+package dev.portero.atlas.text;
 
 public enum FontInfo {
 

--- a/src/main/java/dev/portero/atlas/util/FontInfo.java
+++ b/src/main/java/dev/portero/atlas/util/FontInfo.java
@@ -1,0 +1,78 @@
+package dev.portero.atlas.util;
+
+public enum FontInfo {
+
+    A('A', 5), a('a', 5),
+    B('B', 5), b('b', 5),
+    C('C', 5), c('c', 5),
+    D('D', 5), d('d', 5),
+    E('E', 5), e('e', 5),
+    F('F', 5), f('f', 4),
+    G('G', 5), g('g', 5),
+    H('H', 5), h('h', 5),
+    I('I', 3), i('i', 1),
+    J('J', 5), j('j', 5),
+    K('K', 5), k('k', 4),
+    L('L', 5), l('l', 1),
+    M('M', 5), m('m', 5),
+    N('N', 5), n('n', 5),
+    O('O', 5), o('o', 5),
+    P('P', 5), p('p', 5),
+    Q('Q', 5), q('q', 5),
+    R('R', 5), r('r', 5),
+    S('S', 5), s('s', 5),
+    T('T', 5), t('t', 4),
+    U('U', 5), u('u', 5),
+    V('V', 5), v('v', 5),
+    W('W', 5), w('w', 5),
+    X('X', 5), x('x', 5),
+    Y('Y', 5), y('y', 5),
+    Z('Z', 5), z('z', 5),
+
+    NUM_1('1', 5), NUM_2('2', 5), NUM_3('3', 5),
+    NUM_4('4', 5), NUM_5('5', 5), NUM_6('6', 5),
+    NUM_7('7', 5), NUM_8('8', 5), NUM_9('9', 5),
+    NUM_0('0', 5),
+
+    EXCLAMATION('!', 1), AT('@', 6),
+    HASH('#', 5), DOLLAR('$', 5), PERCENT('%', 5),
+    CARET('^', 5), AMPERSAND('&', 5), ASTERISK('*', 5),
+    LEFT_PAREN('(', 4), RIGHT_PAREN(')', 4),
+    MINUS('-', 5), UNDERSCORE('_', 5), PLUS('+', 5),
+    EQUALS('=', 5),
+
+    LEFT_CURLY('{', 4), RIGHT_CURLY('}', 4),
+    LEFT_BRACKET('[', 3), RIGHT_BRACKET(']', 3),
+    COLON(':', 1), SEMICOLON(';', 1),
+    DOUBLE_QUOTE('"', 3), SINGLE_QUOTE('\'', 1),
+    LESS_THAN('<', 4), GREATER_THAN('>', 4),
+    QUESTION('?', 5), SLASH('/', 5),
+    BACKSLASH('\\', 5), PIPE('|', 1),
+    TILDE('~', 5), BACKTICK('`', 2),
+    PERIOD('.', 1), COMMA(',', 1),
+    SPACE(' ', 3),
+
+    DEFAULT('a', 4);
+
+    private final char character;
+    private final int width;
+
+    FontInfo(char character, int width) {
+        this.character = character;
+        this.width = width;
+    }
+
+    public int getWidth() {
+        return this.width;
+    }
+
+    public static FontInfo fromChar(char c) {
+        for (FontInfo fontInfo : FontInfo.values()) {
+            if (fontInfo.character == c) {
+                return fontInfo;
+            }
+        }
+        return FontInfo.DEFAULT;
+    }
+}
+

--- a/src/main/java/dev/portero/atlas/util/MessageUtil.java
+++ b/src/main/java/dev/portero/atlas/util/MessageUtil.java
@@ -1,0 +1,62 @@
+package dev.portero.atlas.util;
+
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.TextComponent;
+import net.kyori.adventure.text.format.Style;
+import net.kyori.adventure.text.format.TextColor;
+import net.kyori.adventure.text.format.TextDecoration;
+import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
+import net.kyori.adventure.text.serializer.plain.PlainTextComponentSerializer;
+
+public class MessageUtil {
+
+    private static final int CHAT_WIDTH_PX = 320;
+    private static final int SPACE_WIDTH_PX = 4;
+
+    public static Component format(String key) {
+        return LegacyComponentSerializer.legacyAmpersand().deserialize(key);
+    }
+
+    public static Component format(String key, Object... args) {
+        return LegacyComponentSerializer.legacyAmpersand().deserialize(String.format(key, args));
+    }
+
+    public static Component center(Component message) {
+        String plainText = PlainTextComponentSerializer.plainText().serialize(message);
+
+        int messagePxSize = calculateMessageWidth(plainText);
+        int paddingPx = (CHAT_WIDTH_PX - messagePxSize) / 2;
+        int spaceCount = Math.max(0, paddingPx / SPACE_WIDTH_PX);
+
+        return Component.text(" ".repeat(spaceCount)).append(message);
+    }
+
+    public static Component centerDecorated(TextColor color, String message) {
+        Component textComponent = format(message);
+        String plainText = PlainTextComponentSerializer.plainText().serialize(textComponent);
+
+        int messagePxSize = calculateMessageWidth(plainText);
+        int paddingPx = (CHAT_WIDTH_PX - messagePxSize) / 2;
+        int spaceCount = Math.max(0, paddingPx / SPACE_WIDTH_PX);
+
+        if (plainText.isEmpty()) {
+            spaceCount = CHAT_WIDTH_PX / SPACE_WIDTH_PX;
+        }
+
+        Style style = Style.style(color, TextDecoration.STRIKETHROUGH);
+        Style reset = Style.style(color);
+
+        TextComponent decoration = Component.text(" ".repeat(spaceCount), style);
+
+        return !plainText.isEmpty() ? Component.empty().append(decoration).append(textComponent).style(reset)
+                .append(decoration).append(Component.empty()).style(reset) : Component.empty().append(decoration);
+    }
+
+    private static int calculateMessageWidth(String text) {
+        int width = 0;
+        for (char c : text.toCharArray()) {
+            width += FontInfo.fromChar(c).getWidth() + 1;
+        }
+        return Math.max(0, width - 1);
+    }
+}

--- a/src/main/java/dev/portero/atlas/util/MessageUtil.java
+++ b/src/main/java/dev/portero/atlas/util/MessageUtil.java
@@ -1,5 +1,6 @@
 package dev.portero.atlas.util;
 
+import dev.portero.atlas.text.FontInfo;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.TextComponent;
 import net.kyori.adventure.text.format.Style;

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,11 +1,7 @@
 mechanics:
-  tnt_place:
+  explosion_firework:
     enabled: true
-    time: 10
-  tnt_explode:
+  explosion:
     enabled: true
-    time: 10
-    radius: 10
-  tnt_throw:
+  corpse:
     enabled: true
-    time: 10

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,0 +1,11 @@
+mechanics:
+  tnt_place:
+    enabled: true
+    time: 10
+  tnt_explode:
+    enabled: true
+    time: 10
+    radius: 10
+  tnt_throw:
+    enabled: true
+    time: 10


### PR DESCRIPTION
### **Add Core Commands**

This issue tracks the implementation of various core commands for the **Atlas** plugin. Each command is treated as a sub-task for better modular development and testing. Below is the list of planned commands:

#### **Commands**

- [x] **`/restart`**  
  Description: Restart the server gracefully.  
- [x] **`/chatmanager`**  
  Description: Manages chat-related settings (e.g., muting chat, configuring filters, etc.).  
- [x] **`/mechanicmanager`**  
  Description: Controls gameplay mechanics such as enabling/disabling features, tweaking configurations, etc.  